### PR TITLE
Add sets field to exercise database

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,28 +34,38 @@ python3 exercise_database.py init
 ### Adding Entries
 
 Use the `add` command to record an exercise. The body part and laterality
-arguments are validated against predefined lists.
+arguments are validated against predefined lists. A required `--sets` argument
+controls how many values are expected for the weight and reps options.
+For unilateral exercises, provide one weight and rep value per set using
+`--weight` and `--reps`. For bilateral exercises, provide left and right values
+separately using `--weight-left`, `--weight-right`, `--reps-left` and
+`--reps-right`.
 
 Examples:
 
 ```
-# Unilateral example
+
+# Unilateral example (3 sets)
 python3 exercise_database.py add \
     --date 2023-09-07 \
     --body-part Biceps \
     --name "Concentration Curl" \
     --laterality unilateral \
-    --weight 30 \
-    --reps 12
+    --sets 3 \
+    --weight 30 35 35 \
+    --reps 12 10 8
 
-# Bilateral example
+# Bilateral example (2 sets)
 python3 exercise_database.py add \
     --date 2023-09-07 \
     --body-part Chest \
     --name "Bench Press" \
     --laterality bilateral \
-    --weight 135 135 \
-    --reps 10 10
+    --sets 2 \
+    --weight-left 135 145 \
+    --weight-right 135 145 \
+    --reps-left 10 8 \
+    --reps-right 10 8
 ```
 
 ### Listing Entries

--- a/exercise_database.py
+++ b/exercise_database.py
@@ -27,10 +27,11 @@ def initialize_db(db_path: Path = DB_PATH) -> None:
             body_part TEXT NOT NULL,
             exercise_name TEXT NOT NULL,
             laterality TEXT NOT NULL,
-            weight_left INTEGER,
-            weight_right INTEGER,
-            reps_left INTEGER,
-            reps_right INTEGER
+            sets INTEGER NOT NULL,
+            weight_left TEXT,
+            weight_right TEXT,
+            reps_left TEXT,
+            reps_right TEXT
         )
         """
     )
@@ -42,8 +43,13 @@ def add_exercise(
     body_part: str,
     exercise_name: str,
     laterality: str,
-    weights: List[int],
-    reps: List[int],
+    sets: int,
+    weights: Optional[List[int]] = None,
+    reps: Optional[List[int]] = None,
+    weights_left: Optional[List[int]] = None,
+    weights_right: Optional[List[int]] = None,
+    reps_left: Optional[List[int]] = None,
+    reps_right: Optional[List[int]] = None,
     db_path: Path = DB_PATH
 ) -> None:
     if body_part not in BODY_PARTS:
@@ -51,31 +57,50 @@ def add_exercise(
     if laterality not in LATERALITY:
         raise ValueError(f"Invalid laterality: {laterality}")
 
+    if sets <= 0:
+        raise ValueError('Sets must be a positive integer')
+
     if laterality == 'unilateral':
-        if len(weights) != 1 or len(reps) != 1:
-            raise ValueError('Unilateral exercises require one weight and one rep value')
-        weight_left, weight_right = weights[0], None
-        reps_left, reps_right = reps[0], None
+        if weights is None or reps is None:
+            raise ValueError('Unilateral exercises require --weight and --reps')
+        if len(weights) != sets or len(reps) != sets:
+            raise ValueError('Number of weight and rep values must equal sets')
+        weight_left = ','.join(map(str, weights))
+        weight_right = None
+        reps_left = ','.join(map(str, reps))
+        reps_right = None
     else:
-        if len(weights) != 2 or len(reps) != 2:
-            raise ValueError('Bilateral exercises require two weight and two rep values')
-        weight_left, weight_right = weights
-        reps_left, reps_right = reps
+        for arg, name in [
+            (weights_left, 'weight-left'),
+            (weights_right, 'weight-right'),
+            (reps_left, 'reps-left'),
+            (reps_right, 'reps-right'),
+        ]:
+            if arg is None:
+                raise ValueError(f'Bilateral exercises require --{name}')
+            if len(arg) != sets:
+                raise ValueError(f'--{name} must have {sets} values')
+
+        weight_left = ','.join(map(str, weights_left))
+        weight_right = ','.join(map(str, weights_right))
+        reps_left = ','.join(map(str, reps_left))
+        reps_right = ','.join(map(str, reps_right))
 
     conn = get_connection(db_path)
     cur = conn.cursor()
     cur.execute(
         """
         INSERT INTO exercises (
-            date_completed, body_part, exercise_name, laterality,
+            date_completed, body_part, exercise_name, laterality, sets,
             weight_left, weight_right, reps_left, reps_right
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             date_completed,
             body_part,
             exercise_name,
             laterality,
+            sets,
             weight_left,
             weight_right,
             reps_left,
@@ -105,8 +130,15 @@ def parse_args() -> argparse.Namespace:
     add_parser.add_argument('--body-part', required=True, choices=BODY_PARTS)
     add_parser.add_argument('--name', required=True, help='Exercise name')
     add_parser.add_argument('--laterality', required=True, choices=LATERALITY)
-    add_parser.add_argument('--weight', required=True, nargs='+', type=int)
-    add_parser.add_argument('--reps', required=True, nargs='+', type=int)
+    add_parser.add_argument('--sets', required=True, type=int)
+
+    add_parser.add_argument('--weight', nargs='+', type=int)
+    add_parser.add_argument('--reps', nargs='+', type=int)
+
+    add_parser.add_argument('--weight-left', nargs='+', type=int)
+    add_parser.add_argument('--weight-right', nargs='+', type=int)
+    add_parser.add_argument('--reps-left', nargs='+', type=int)
+    add_parser.add_argument('--reps-right', nargs='+', type=int)
 
     list_parser = subparsers.add_parser('list', help='List all exercises')
 
@@ -118,14 +150,23 @@ def main() -> None:
         initialize_db()
         print(f'Database initialized at {DB_PATH}')
     elif args.command == 'add':
-        add_exercise(
+        add_kwargs = dict(
             date_completed=args.date,
             body_part=args.body_part,
             exercise_name=args.name,
             laterality=args.laterality,
-            weights=args.weight,
-            reps=args.reps,
+            sets=args.sets,
         )
+        if args.laterality == 'unilateral':
+            add_kwargs.update(weights=args.weight, reps=args.reps)
+        else:
+            add_kwargs.update(
+                weights_left=args.weight_left,
+                weights_right=args.weight_right,
+                reps_left=args.reps_left,
+                reps_right=args.reps_right,
+            )
+        add_exercise(**add_kwargs)
         print('Exercise added.')
     elif args.command == 'list':
         list_exercises()


### PR DESCRIPTION
## Summary
- store number of sets for each entry
- accept set-specific weight/reps values for unilateral and bilateral exercises
- document new command line usage

## Testing
- `python3 -m py_compile exercise_database.py make_workout_pdf.py`
- `python3 exercise_database.py init`
- `python3 exercise_database.py add --date 2023-10-10 --body-part Biceps --name Test --laterality unilateral --sets 2 --weight 10 20 --reps 8 8`
- `python3 exercise_database.py add --date 2023-10-11 --body-part Chest --name Bench --laterality bilateral --sets 2 --weight-left 100 110 --weight-right 100 110 --reps-left 10 8 --reps-right 10 8`
- `python3 exercise_database.py list`


------
https://chatgpt.com/codex/tasks/task_e_686ea6458c5883308284739b8c22d5f9