### PR TITLE
Remove body part from text export

### DIFF
--- a/exercise_database.py
+++ b/exercise_database.py
@@ -154,12 +154,12 @@ def export_exercises(ids: List[int], output: Path, db_path: Path = DB_PATH) -> N
             if not row:
                 continue
             _, _, body_part, name, lat, _, weight_l, weight_r, reps_l, reps_r = row
-            title = f"{body_part} - {name}"
+            title = name
             if lat == 'unilateral':
                 w_l = parse_int_list(weight_l)
                 r_l = parse_int_list(reps_l)
                 sets_str = join_sets(w_l, r_l)
-                line = f"\u2022 {title} - {sets_str}"
+                line = f"{title} - {sets_str}"
             else:
                 w_left = parse_int_list(weight_l)
                 r_left = parse_int_list(reps_l)
@@ -167,7 +167,7 @@ def export_exercises(ids: List[int], output: Path, db_path: Path = DB_PATH) -> N
                 r_right = parse_int_list(reps_r)
                 left_str = join_sets(w_left, r_left)
                 right_str = join_sets(w_right, r_right)
-                line = f"\u2022 {title} - L \u2014 {left_str} - R \u2014 {right_str}"
+                line = f"{title} - L \u2014 {left_str} - R \u2014 {right_str}"
             f.write(line + '\n')
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Summary
- revert PDF rendering changes
- drop bullet and body part from database export lines

## Testing
- `python3 -m py_compile make_workout_pdf.py exercise_database.py`
- `python3 make_workout_pdf.py -n "Demo" -d 2023-01-01 && pdftotext '2023-01-01 Workout.pdf' - | head -n 8`
- `python3 exercise_database.py init`
- `python3 exercise_database.py add --date 2023-01-01 --body-part Chest --name "Bench" --laterality bilateral --sets 1 --weight-left 50 --weight-right 50 --reps-left 10 --reps-right 10`
- `python3 exercise_database.py export --ids 1 --output export.txt && cat export.txt`


------
https://chatgpt.com/codex/tasks/task_e_68781b1e5cb48330af5b35028011a3b9